### PR TITLE
Features/send all

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -180,7 +180,7 @@ ipcMain.on('req:validate-address', async (event, args) => {
 })
 
 ipcMain.on('req:get-fee', async (event, args) => {
-  const fee = await getFee(args.network, args.wallet, args.amount, args.address);
+  const fee = await getFee(args.network, args.wallet, args.sendAll, args.amount, args.address);
   event.reply('res:get-fee', { fee: fee });
 })
 

--- a/src/background.js
+++ b/src/background.js
@@ -185,7 +185,7 @@ ipcMain.on('req:get-fee', async (event, args) => {
 })
 
 ipcMain.on('req:send-transaction', async (event, args) => {
-  const result = await sendTransaction(args.network, args.wallet, args.amount, args.address, args.passphrase, args.metadata);
+  const result = await sendTransaction(args.network, args.wallet, args.sendAll, args.amount, args.address, args.passphrase, args.metadata);
   event.reply('res:send-transaction', { transaction: result });
 })
 

--- a/src/components/wallet/WalletDetails.vue
+++ b/src/components/wallet/WalletDetails.vue
@@ -252,7 +252,8 @@
             validAddress: true,
             validPassphrase: true,
             validAmount: true,
-            readonlyAmount: false
+            readonlyAmount: false,
+            sendAll: false
         },
         mintForm: {
             asset: 'lift',
@@ -365,6 +366,7 @@
     methods: {
         toggleSendAll() {
             const shouldSendAll = this.sendForm.readonlyAmount;
+            this.sendForm.sendAll = true;
             if (shouldSendAll) {
                 this.sendForm.amount = this.wallet.balance/1000000;
                 this.sendForm.amountFormatted = `${parseFloat(this.sendForm.amount).toFixed(6)}`;
@@ -525,8 +527,9 @@
                         wallet: this.walletId, 
                         address: this.sendForm.address, 
                         amount: this.sendForm.amount*1000000 , 
+                        sendAll: this.sendForm.sendAll,
                         passphrase: this.sendForm.passphrase,
-                        metadata: metadata    
+                        metadata: metadata
                     });
             }
         },

--- a/src/components/wallet/WalletDetails.vue
+++ b/src/components/wallet/WalletDetails.vue
@@ -467,8 +467,13 @@
         getFee() {
             if(this.sendForm.address.length > 0)
             {
-                const amount = (this.sendForm.amount < 1000000) ? 1000000 : this.sendForm.amount;
-                ipcRenderer.send('req:get-fee', { network: 'testnet', wallet: this.walletId, address: this.sendForm.address, amount: amount});
+                let amount;
+                if ( this.sendForm.sendAll ) {
+                  amount = this.wallet.balance;
+                } else {
+                  amount = (this.sendForm.amount < 1000000) ? 1000000 : this.sendForm.amount;
+                }
+                ipcRenderer.send('req:get-fee', { network: 'testnet', wallet: this.walletId, address: this.sendForm.address, sendAll: this.sendForm.sendAll, amount: amount});
             }
             
         },
@@ -521,13 +526,19 @@
                 let metadata = null;
                 if(this.sendForm.metadataFile != null) metadata = this.sendForm.metadataFile.path;
                 console.log(metadata);
+                let amount;
+                if ( this.sendForm.sendAll ) {
+                  amount = this.wallet.balance;
+                } else {
+                  amount = this.sendForm.amount*1000000;
+                }
                 ipcRenderer.send(
                     'req:send-transaction', 
                     { 
                         network: 'testnet', 
                         wallet: this.walletId, 
                         address: this.sendForm.address, 
-                        amount: this.sendForm.amount*1000000 , 
+                        amount: amount ,
                         sendAll: this.sendForm.sendAll,
                         passphrase: this.sendForm.passphrase,
                         metadata: metadata

--- a/src/components/wallet/WalletDetails.vue
+++ b/src/components/wallet/WalletDetails.vue
@@ -386,6 +386,7 @@
                     address: '',
                     amount: 0,
                     amountFormatted: '0.000000',
+                    sendAll: false,
                     fee: 0,
                     feeFormatted: '0.000000',
                     total: 0,

--- a/src/components/wallet/WalletDetails.vue
+++ b/src/components/wallet/WalletDetails.vue
@@ -110,10 +110,18 @@
                                                 @focus="sendAdaFocusIn"
                                                 :hint="`Est. Fee: ${sendForm.feeFormatted}`"
                                                 persistent-hint
-                                                :disabled="isSendingAda"
+                                                :disabled="isSendingAda || sendForm.readonlyAmount"
                                                 required
                                                 >
                                             </v-text-field>
+
+                                            <v-checkbox
+                                                v-model="sendForm.readonlyAmount"
+                                                class="mt-5"
+                                                label="Send All"
+                                                @change="toggleSendAll"
+                                                ></v-checkbox>
+
 
                                             <v-input
                                                 class="mt-5"
@@ -243,7 +251,8 @@
             metadataFile: null,
             validAddress: true,
             validPassphrase: true,
-            validAmount: true
+            validAmount: true,
+            readonlyAmount: false
         },
         mintForm: {
             asset: 'lift',
@@ -355,6 +364,14 @@
         ipcRenderer.on('res:mint-asset', this.transactionResult)
     },
     methods: {
+        toggleSendAll() {
+            const shouldSendAll = this.sendForm.readonlyAmount;
+            if (shouldSendAll) {
+                this.sendForm.amount = this.wallet.balance/1000000;
+                this.sendForm.amountFormatted = `${parseFloat(this.sendForm.amount).toFixed(6)}`;
+                this.getFee();
+            }
+        },
         sendToken(){
             console.log("send token");
         },
@@ -405,6 +422,16 @@
 
                 this.sendForm.validAddress = true;
                 this.setSendAdaFee(fee);
+
+                if (this.sendForm.readonlyAmount) {
+                    const availableWithoutFee = this.wallet.balance - args.fee;
+
+                    this.sendForm.amount = availableWithoutFee/1000000;
+                    this.sendForm.amountFormatted = `${parseFloat(availableWithoutFee/1000000).toFixed(6)}`;
+
+                    this.sendForm.total =  this.wallet.balance;
+                    this.sendForm.totalFormatted = `${parseFloat(this.sendForm.total/1000000).toFixed(6)}`;
+                }
             }else{
                 this.sendForm.validAddress = false;
             }
@@ -498,7 +525,7 @@
                         network: 'testnet', 
                         wallet: this.walletId, 
                         address: this.sendForm.address, 
-                        amount: this.sendForm.amount*1000000, 
+                        amount: this.sendForm.amount*1000000 , 
                         passphrase: this.sendForm.passphrase,
                         metadata: metadata    
                     })

--- a/src/core/cardano-cli.js
+++ b/src/core/cardano-cli.js
@@ -33,7 +33,7 @@ export function buildTxIn(addressUtxos, amount, fee) {
     return txIn;
 }
 
-export function buildTransaction(era, fee, ttl, toAddress, amount, changeAddress, txIns, metadataPath, outputFile){
+export function buildTransaction(era, fee, ttl, toAddress, amount, changeAddress, txIns, metadataPath, outputFile, isDraft = false){
     const cardanoCli = path.resolve('.', cardanoPath, process.platform, 'cardano-cli');
     let tx = `"${cardanoCli}" transaction build-raw --${era} --fee ${parseInt(fee)} --ttl ${parseInt(ttl)}`;
     let totalUsed = 0;
@@ -44,7 +44,7 @@ export function buildTransaction(era, fee, ttl, toAddress, amount, changeAddress
     }
     tx += ` --tx-out ${toAddress}+${parseInt(amount)}`;
     let change = parseInt(totalUsed) - parseInt(amount) - parseInt(fee);
-    if(change >0 )  tx += ` --tx-out ${changeAddress}+${change}`;
+    if(change >0 || isDraft)  tx += ` --tx-out ${changeAddress}+${change}`;
     if(metadataPath != null) tx += ` --metadata-json-file "${metadataPath}"`;
     
     tx += ` --out-file "${outputFile}"`;

--- a/src/core/cardano-cli.js
+++ b/src/core/cardano-cli.js
@@ -33,18 +33,26 @@ export function buildTxIn(addressUtxos, amount, fee) {
     return txIn;
 }
 
-export function buildTransaction(era, fee, ttl, toAddress, amount, changeAddress, txIns, metadataPath, outputFile, isDraft = false){
+export function buildTransaction(era, fee, ttl, toAddress, amount, changeAddress, txIns, metadataPath, outputFile, isSendAll){
     const cardanoCli = path.resolve('.', cardanoPath, process.platform, 'cardano-cli');
     let tx = `"${cardanoCli}" transaction build-raw --${era} --fee ${parseInt(fee)} --ttl ${parseInt(ttl)}`;
     let totalUsed = 0;
+
     for(let txIn of txIns)
     {
         totalUsed += parseInt(txIn.value)
         tx += ` --tx-in ${txIn.txHash}#${txIn.index}`;
     }
-    tx += ` --tx-out ${toAddress}+${parseInt(amount)}`;
-    let change = parseInt(totalUsed) - parseInt(amount) - parseInt(fee);
-    if(change >0 || isDraft)  tx += ` --tx-out ${changeAddress}+${change}`;
+
+    if (isSendAll) {
+      let outputAmount = parseInt(amount) - parseInt(fee);
+      tx += ` --tx-out ${toAddress}+${outputAmount}`;
+    } else {
+      let change = parseInt(totalUsed) - parseInt(amount) - parseInt(fee);
+      if(change >0)  tx += ` --tx-out ${changeAddress}+${change}`;
+      tx += ` --tx-out ${toAddress}+${parseInt(amount)}`;
+    }
+
     if(metadataPath != null) tx += ` --metadata-json-file "${metadataPath}"`;
     
     tx += ` --out-file "${outputFile}"`;

--- a/src/core/cardano-cli.js
+++ b/src/core/cardano-cli.js
@@ -44,8 +44,7 @@ export function buildTransaction(era, fee, ttl, toAddress, amount, changeAddress
     }
     tx += ` --tx-out ${toAddress}+${parseInt(amount)}`;
     let change = parseInt(totalUsed) - parseInt(amount) - parseInt(fee);
-    if(change < 0) change = 0;
-    tx += ` --tx-out ${changeAddress}+${change}`;
+    if(change >0 )  tx += ` --tx-out ${changeAddress}+${change}`;
     if(metadataPath != null) tx += ` --metadata-json-file "${metadataPath}"`;
     
     tx += ` --out-file "${outputFile}"`;

--- a/src/services/wallet.service.js
+++ b/src/services/wallet.service.js
@@ -219,7 +219,7 @@ export async function getBalance(network, name) {
     return getTotalUtxoBalance(addressUtxos);
 }
 
-export async function getFee(network, name, amount, toAddress) {
+export async function getFee(network, name, sendAll, amount, toAddress) {
     const walletDir = path.resolve(walletsPath, network, name);
 
     //tx/key file paths

--- a/src/services/wallet.service.js
+++ b/src/services/wallet.service.js
@@ -238,7 +238,7 @@ export async function getFee(network, name, amount, toAddress) {
     let draftTxIns = buildTxIn(addressUtxos, amount, 0);
 
     //build draft transaction
-    let draftTx = buildTransaction('allegra-era', 0, 0, toAddress, amount, changes[0].address, draftTxIns, null, txDraftPath)
+    let draftTx = buildTransaction('allegra-era', 0, 0, toAddress, amount, changes[0].address, draftTxIns, null, txDraftPath, sendAll)
     await cli(draftTx);
 
     //get protocol parameters
@@ -368,7 +368,7 @@ export async function refreshProtocolParametersFile(network) {
 }
 
 
-export async function sendTransaction(network, name, amount, toAddress, passphrase, metadataPath) {
+export async function sendTransaction(network, name, sendAll, amount, toAddress, passphrase, metadataPath) {
     const walletDir = path.resolve(walletsPath, network, name);
 
     //tx/key file paths
@@ -392,7 +392,7 @@ export async function sendTransaction(network, name, amount, toAddress, passphra
         let draftTxIns = buildTxIn(addressUtxos, amount, 0);
 
         //build draft transaction
-        let draftTx = buildTransaction('allegra-era', 0, 0, toAddress, amount, changes[0].address, draftTxIns, metadataPath, txDraftPath, true)
+        let draftTx = buildTransaction('allegra-era', 0, 0, toAddress, amount, changes[0].address, draftTxIns, metadataPath, txDraftPath, sendAll)
         await cli(draftTx);
 
         //refresh protocol parameters
@@ -416,7 +416,7 @@ export async function sendTransaction(network, name, amount, toAddress, passphra
         let rawTxIns = buildTxIn(addressUtxos, amount, fee);
 
         //build raw transaction
-        let rawTx = buildTransaction('allegra-era', fee, ttl, toAddress, amount, changes[0].address, rawTxIns, metadataPath, txRawPath)
+        let rawTx = buildTransaction('allegra-era', fee, ttl, toAddress, amount, changes[0].address, rawTxIns, metadataPath, txRawPath, sendAll)
         await cli(rawTx);
 
         await getSigningKeys(draftTxIns, passphrase, walletDir, signingKeyPaths, addresses, changes);

--- a/src/services/wallet.service.js
+++ b/src/services/wallet.service.js
@@ -392,7 +392,7 @@ export async function sendTransaction(network, name, amount, toAddress, passphra
         let draftTxIns = buildTxIn(addressUtxos, amount, 0);
 
         //build draft transaction
-        let draftTx = buildTransaction('allegra-era', 0, 0, toAddress, amount, changes[0].address, draftTxIns, metadataPath, txDraftPath)
+        let draftTx = buildTransaction('allegra-era', 0, 0, toAddress, amount, changes[0].address, draftTxIns, metadataPath, txDraftPath, true)
         await cli(draftTx);
 
         //refresh protocol parameters


### PR DESCRIPTION
Opening this one from a local branch in favor of #52 from elribo's remote one. 

With this (working one!) I tried to map `send-all` UI with what we do in the backend with `cardano-cli` for the sake of intelligibility. But I completely broke the fee preview and "Total ADA" view on the UI :sweat_smile: 

PS: be careful to test this on wallets that DO NOT hold any other token! It took me a while to figure out why I was getting "value not conserved" lol